### PR TITLE
use typed fuel only in the frontend

### DIFF
--- a/smc/scalar_product_alt_syntax.v
+++ b/smc/scalar_product_alt_syntax.v
@@ -89,16 +89,16 @@ Definition vec x : data := inr x.
 
 (* Local wrappers for proc constructors to work around ssreflect syntax *)
 (* Now fuel-indexed *)
-Definition PInit {n} (x : data) (p : proc data n) : proc data n.+1 := Init x p.
-Definition PSend {n} (party : nat) (x : data) (p : proc data n) : proc data n.+1 := Send party x p.
-Definition PRecv {n} (party : nat) (f : data -> proc data n) : proc data n.+1 := Recv party f.
-Definition PRet (x : data) : proc data 2 := Ret x.
+Definition PInit {n} (x : data) (p : sproc data n) : sproc data n.+1 := sInit x p.
+Definition PSend {n} (party : nat) (x : data) (p : sproc data n) : sproc data n.+1 := sSend party x p.
+Definition PRecv {n} (party : nat) (f : data -> sproc data n) : sproc data n.+1 := sRecv party f.
+Definition PRet (x : data) : sproc data 2 := sRet x.
 
 (* Specialized receive operations - fuel-indexed *)
-Definition Recv_one {n} frm (f : TX -> proc data n) : proc data n.+1 :=
-  Recv frm (fun x => if x is inl v then f v else Fail).
-Definition Recv_vec {n} frm (f : VX -> proc data n) : proc data n.+1 :=
-  Recv frm (fun x => if x is inr v then f v else Fail).
+Definition Recv_one {n} frm (f : TX -> sproc data n) : sproc data n.+1 :=
+  sRecv frm (fun x => if x is inl v then f v else sFail).
+Definition Recv_vec {n} frm (f : VX -> sproc data n) : sproc data n.+1 :=
+  sRecv frm (fun x => if x is inr v then f v else sFail).
 
 (** * Data wrapper shorthand notations *)
 
@@ -110,14 +110,14 @@ Notation "& x" := (vec x) (at level 0, x at level 0) : smc_scope.
 (** * Basic custom syntax notations *)
 
 (* Finish - terminal state *)
-Notation "'Finish'" := Finish (in custom smc at level 0).
+Notation "'Finish'" := sFinish (in custom smc at level 0).
 
 (* Ret - return a value *)
 Notation "'Ret' x" := (PRet x) 
   (in custom smc at level 80, x constr at level 0).
 
 (* Fail - error state *)  
-Notation "'Fail'" := Fail (in custom smc at level 0).
+Notation "'Fail'" := sFail (in custom smc at level 0).
 
 (** * Sequencing with · (middle dot) or ; (semicolon as ASCII fallback) *)
 
@@ -244,7 +244,7 @@ Notation "x" := x (in custom smc at level 0, x ident).
 
 (* Commodity server's protocol - Unicode version *)
 (* Fuel automatically inferred *)
-Definition pcoserv (sa sb: VX) (ra : TX) : proc data _ :=
+Definition pcoserv (sa sb: VX) (ra : TX) : sproc data _ :=
   {| Init &sa　&sb　!ra ·
      Send⟨alice⟩ &sa ·
      Send⟨alice⟩ !ra ·
@@ -253,7 +253,7 @@ Definition pcoserv (sa sb: VX) (ra : TX) : proc data _ :=
      Finish |}.
 
 (* Alice's protocol - Unicode version *)
-Definition palice (xa : VX) : proc data _ :=
+Definition palice (xa : VX) : sproc data _ :=
   {| Init &xa ·
      Recv_vec⟨coserv⟩ λ sa ·
      Recv_one⟨coserv⟩ λ ra ·
@@ -263,7 +263,7 @@ Definition palice (xa : VX) : proc data _ :=
      Ret !(t - (xb' *d sa) + ra) |}.
 
 (* Bob's protocol - Unicode version *)
-Definition pbob (xb : VX) (yb : TX) : proc data _ :=
+Definition pbob (xb : VX) (yb : TX) : sproc data _ :=
   {| Init &xb　!yb ·
      Recv_vec⟨coserv⟩ λ sb ·
      Recv_one⟨coserv⟩ λ rb ·
@@ -277,7 +277,7 @@ Definition pbob (xb : VX) (yb : TX) : proc data _ :=
 (******************************************************************************)
 
 (* Commodity server's protocol - ASCII version *)
-Definition pcoserv_ascii (sa sb: VX) (ra : TX) : proc data _ :=
+Definition pcoserv_ascii (sa sb: VX) (ra : TX) : sproc data _ :=
   {| Init (&sa, &sb, !ra) ;
      Send<alice> &sa ;
      Send<alice> !ra ;
@@ -286,7 +286,7 @@ Definition pcoserv_ascii (sa sb: VX) (ra : TX) : proc data _ :=
      Finish |}.
 
 (* Alice's protocol - ASCII version *)
-Definition palice_ascii (xa : VX) : proc data _ :=
+Definition palice_ascii (xa : VX) : sproc data _ :=
   {| Init &xa ;
      Recv_vec<coserv> fun sa =>
      Recv_one<coserv> fun ra =>
@@ -296,7 +296,7 @@ Definition palice_ascii (xa : VX) : proc data _ :=
      Ret !(t - (xb' *d sa) + ra) |}.
 
 (* Bob's protocol - ASCII version *)
-Definition pbob_ascii (xb : VX) (yb : TX) : proc data _ :=
+Definition pbob_ascii (xb : VX) (yb : TX) : sproc data _ :=
   {| Init (&xb, !yb) ;
      Recv_vec<coserv> fun sb =>
      Recv_one<coserv> fun rb =>
@@ -325,7 +325,7 @@ Local Close Scope smc_scope.
 Lemma pcoserv_eq sa sb ra : pcoserv sa sb ra = 
   PInit (vec sa) (PInit (vec sb) (PInit (one ra)
     (PSend alice (vec sa) (PSend alice (one ra)
-      (PSend bob (vec sb) (PSend bob (one (sa *d sb - ra)) Finish)))))).
+      (PSend bob (vec sb) (PSend bob (one (sa *d sb - ra)) sFinish)))))).
 Proof. reflexivity. Qed.
 
 (* Verify palice expands correctly *)

--- a/smc/scalar_product_program.v
+++ b/smc/scalar_product_program.v
@@ -60,39 +60,39 @@ Definition one x : data := inl x.
 Definition vec x : data := inr x.
 
 (* Recv wrappers for fuel-indexed proc type *)
-Definition Recv_one {n} frm (f : TX -> proc data n) : proc data n.+1 :=
-  Recv frm (fun x => if x is inl v then f v else Fail).
-Definition Recv_vec {n} frm (f : VX -> proc data n) : proc data n.+1 :=
-  Recv frm (fun x => if x is inr v then f v else Fail).
+Definition Recv_one {n} frm (f : TX -> sproc data n) : sproc data n.+1 :=
+  sRecv frm (fun x => if x is inl v then f v else sFail).
+Definition Recv_vec {n} frm (f : VX -> sproc data n) : sproc data n.+1 :=
+  sRecv frm (fun x => if x is inr v then f v else sFail).
 
 (* Fuel is automatically inferred via _ *)
-Definition pcoserv (sa sb: VX) (ra : TX) : proc data _ :=
-  Init (vec sa) (
-  Init (vec sb) (
-  Init (one ra) (
-  Send alice (vec sa) (
-  Send alice (one ra) (
-  Send bob (vec sb) (
-  Send bob (one (sa *d sb - ra)) Finish)))))).
+Definition pcoserv (sa sb: VX) (ra : TX) : sproc data _ :=
+  sInit (vec sa) (
+  sInit (vec sb) (
+  sInit (one ra) (
+  sSend alice (vec sa) (
+  sSend alice (one ra) (
+  sSend bob (vec sb) (
+  sSend bob (one (sa *d sb - ra)) sFinish)))))).
 
-Definition palice (xa : VX) : proc data _ :=
-  Init (vec xa) (
+Definition palice (xa : VX) : sproc data _ :=
+  sInit (vec xa) (
   Recv_vec coserv (fun sa =>
   Recv_one coserv (fun ra =>
-  Send bob (vec (xa + sa)) (
+  sSend bob (vec (xa + sa)) (
   Recv_vec bob (fun xb' =>
   Recv_one bob (fun t =>
-  Ret (one (t - (xb' *d sa) + ra)))))))).
+  sRet (one (t - (xb' *d sa) + ra)))))))).
 
-Definition pbob (xb : VX) (yb : TX) : proc data _ :=
-  Init (vec xb) (
-  Init (one yb) (
+Definition pbob (xb : VX) (yb : TX) : sproc data _ :=
+  sInit (vec xb) (
+  sInit (one yb) (
   Recv_vec coserv (fun sb =>
   Recv_one coserv (fun rb =>
   Recv_vec alice (fun xa' =>
   let t := xa' *d xb + rb - yb in
-    Send alice (vec (xb + sb))
-    (Send alice (one t) (Ret (one yb)))))))).
+    sSend alice (vec (xb + sb))
+    (sSend alice (one t) (sRet (one yb)))))))).
 
 Variables (sa sb: VX) (ra yb: TX) (xa xb: VX).
 
@@ -101,7 +101,7 @@ Definition smc_procs : seq (aproc data) :=
   [procs palice xa; pbob xb yb; pcoserv sa sb ra].
 
 Definition smc_scalar_product h :=
-  interp h smc_procs (nseq 3 [::]).
+  interp h (map get_proc smc_procs) (nseq 3 [::]).
 
 (* Fuel bound computed from program structure: 8 + 9 + 8 = 25
    - palice: 8 (Init + 2*Recv + Send + 2*Recv + Ret=2)
@@ -114,7 +114,7 @@ Lemma smc_max_fuel_ok : smc_max_fuel = [> smc_procs].
 Proof. reflexivity. Qed.
 
 Definition smc_scalar_product_traces :=
-  interp_traces [> smc_procs] smc_procs.
+  interp_traces [> smc_procs] (map get_proc smc_procs).
 
 Definition smc_scalar_product_tracesT := smc_max_fuel.-bseq data.
 

--- a/smc/scalar_product_proof.v
+++ b/smc/scalar_product_proof.v
@@ -82,7 +82,7 @@ Let smc_scalar_product_procs := smc_procs dotproduct sa sb ra yb xa xb.
 (* With fuel-indexed proc, the result has aproc (packed processes) *)
 Lemma smc_scalar_product_ok :
   smc_scalar_product dotproduct sa sb ra yb xa xb smc_max_fuel =
-  ([:: pack Finish; pack Finish; pack Finish],
+  ([:: Finish; Finish; Finish],
    [:: [:: one ya;
            one t;
            vec xb';

--- a/smc/smc_interpreter.v
+++ b/smc/smc_interpreter.v
@@ -44,61 +44,79 @@ Section interp.
 Variable data : Type.
 
 (* Fuel-indexed process type: fuel is computed by type inference *)
-Inductive proc : nat -> Type :=
-  | Init : forall n, data -> proc n -> proc n.+1
-  | Send : forall n, nat -> data -> proc n -> proc n.+1
-  | Recv : forall n, nat -> (data -> proc n) -> proc n.+1
-  | Ret : data -> proc 2
-  | Finish : proc 1
-  | Fail : forall n, proc n.
+Inductive sproc : nat -> Type :=
+  | sInit : forall n, data -> sproc n -> sproc n.+1
+  | sSend : forall n, nat -> data -> sproc n -> sproc n.+1
+  | sRecv : forall n, nat -> (data -> sproc n) -> sproc n.+1
+  | sRet : data -> sproc 2
+  | sFinish : sproc 1
+  | sFail : forall n, sproc n.
 
 (* Existential wrapper for heterogeneous process lists *)
-Definition aproc := { n : nat & proc n }.
+Definition aproc := {n: nat & sproc n}.
+
+(* Dynamic version *)
+Inductive proc :=
+  | Init : data -> proc -> proc
+  | Send : nat -> data -> proc -> proc
+  | Recv : nat -> (data -> proc) -> proc
+  | Ret : data -> proc
+  | Finish : proc
+  | Fail : proc.
+
+Fixpoint as_proc n (p : sproc n) :=
+  match p with
+  | sInit m x p => Init x (as_proc p)
+  | sSend m i x p => Send i x (as_proc p)
+  | sRecv m i p => Recv i (fun x => as_proc (p x))
+  | sRet x => Ret x
+  | sFinish => Finish
+  | sFail _ => Fail
+  end.
 
 (* Extract fuel from packed process *)
 Definition get_fuel (p : aproc) : nat := projT1 p.
 
 (* Extract process from packed process *)
-Definition get_proc (p : aproc) : proc (get_fuel p) := projT2 p.
+Definition get_sproc (p : aproc) : sproc (get_fuel p) := projT2 p.
+Definition get_proc (p : aproc) := as_proc (get_sproc p).
 
 (* Pack a process into aproc *)
-Definition pack {n} (p : proc n) : aproc := existT _ n p.
+Definition pack {n} (p : sproc n) : aproc := existT _ n p.
 
 (* Default packed process (Fail at fuel 0) *)
-Definition default_aproc : aproc := pack (@Fail 0).
+Definition default_aproc : aproc := pack (@sFail 0).
 
 (* Compute sum of all fuels - used as interpreter fuel *)
 Definition sum_fuel (ps : seq aproc) : nat := 
   foldr (fun p acc => get_fuel p + acc) 0 ps.
 
-(* Step function for aproc *)
-Definition step (ps : seq aproc) (trace : seq data) (i : nat) :=
-  let p := nth default_aproc ps i in
+(* Step function for normal proc *)
+Definition step (ps : seq proc) (trace : seq data) (i : nat) :=
+  let p := nth Fail ps i in
   let nop := (p, trace, false) in
-  match get_proc p in proc n return (aproc * seq data * bool) with
-  | @Recv n frm f =>
-      match get_proc (nth default_aproc ps frm) in proc m 
-            return (aproc * seq data * bool) with
-      | @Send m dst v next => 
-          if dst == i then (pack (f v), v::trace, true) else nop
+  match p with
+  | Recv frm f =>
+      match nth Fail ps frm with
+      | Send dst v next => 
+          if dst == i then (f v, v::trace, true) else nop
       | _ => nop
       end
-  | @Send n dst w next =>
-      match get_proc (nth default_aproc ps dst) in proc m
-            return (aproc * seq data * bool) with
-      | @Recv m frm f =>
-          if frm == i then (pack next, trace, true) else nop
+  | Send dst w next =>
+      match nth Fail ps dst with
+      | Recv frm f =>
+          if frm == i then (next, trace, true) else nop
       | _ => nop
       end
-  | @Init n d next =>
-      (pack next, d::trace, true)
+  | Init d next =>
+      (next, d::trace, true)
   | Ret d =>
-      (pack Finish, d :: trace, true)
+      (Finish, d :: trace, true)
   | Finish => nop
-  | @Fail n => nop
+  | Fail => nop
   end.
 
-Fixpoint interp h (ps : seq aproc) (traces : seq (seq data)) :=
+Fixpoint interp h (ps : seq proc) (traces : seq (seq data)) :=
   if h is h.+1 then
     let ps_trs' := [seq step ps (nth [::] traces i) i
                    | i <- iota 0 (size ps)] in
@@ -128,7 +146,6 @@ Lemma map_extract n m A B (l : lens n m) (f : A -> B) v :
   map_tuple f (extract l v) = extract l (map_tuple f v).
 Proof. by apply: eq_from_tnth => i; rewrite !tnth_map. Qed.
 
-(*
 Inductive rred {n} : forall {m},lens n m ->
       m.-tuple proc -> m.-tuple proc -> m.-tuple (seq data) -> Prop :=
   | rinit i x p : rred [tuple i] [tuple Init x p] [tuple p] [tuple [:: x]]
@@ -308,21 +325,28 @@ case Hpi: (ps !_ i) => [x p | j x p | j p | x ||].
   + exact: Hpss.
 (* remaining cases are similar, but we need to find a shorted way *)
 Abort.
-*)
 End interp.
 
 Arguments Finish {data}.
-Arguments Fail {data n}.
-Arguments Init {data n}.
-Arguments Send {data n}.
-Arguments Recv {data n}.
+Arguments Fail {data}.
+Arguments Init {data}.
+Arguments Send {data}.
+Arguments Recv {data}.
+Arguments get_proc {data}.
+
+Arguments as_proc {data n}.
 Arguments pack {data n}.
+Arguments sFinish {data}.
+Arguments sFail {data n}.
+Arguments sInit {data n}.
+Arguments sSend {data n}.
+Arguments sRecv {data n}.
 
 Section traces.
 Variable data : eqType.
 Local Open Scope nat_scope.
 
-Lemma size_traces h (procs : seq (aproc data)) :
+Lemma size_traces h (procs : seq (proc data)) :
   forall s, s \in (run_interp h procs).2 -> size s <= h.
 Proof.
 clear.
@@ -353,17 +377,17 @@ have Hsz : size (nth [::] traces i) < k - h.
   by rewrite leqNgt.
 set p := nth _ _ _.
 (* Case on process type - 6 constructors: Init, Send, Recv, Ret, Finish, Fail *)
-case: (get_proc p) => [n1 d1 p1|n1 dst1 d1 p1|n1 frm1 f1|d1||n1] /=.
+case: p => [d1 p1|dst1 d1 p1|frm1 f1|d1||] /=.
 (* Init: s = d1 :: nth... -> size s <= k - h *)
 - by move=> ->; exact Hsz.
 (* Send: nested match on destination *)
 - move=> ->.
-  case: (get_proc _) => [n2 d2 p2|n2 dst2 d2 p2|n2 frm2 f2|d2||n2] /=;
+  case: nth => [d2 p2|dst2 d2 p2|frm2 f2|d2||] /=;
     try exact (ltnW Hsz).
   by case: ifP => _ /=; exact (ltnW Hsz).
 (* Recv: nested match on source *)
 - move=> ->.
-  case: (get_proc _) => [n2 d2 p2|n2 dst2 d2 p2|n2 frm2 f2|d2||n2] /=;
+  case: nth => [d2 p2|dst2 d2 p2|frm2 f2|d2||] /=;
     try exact (ltnW Hsz).
   by case: ifP => _ /=; [exact Hsz | exact (ltnW Hsz)].
 (* Ret: s = d1 :: nth... -> size s <= k - h *)
@@ -374,7 +398,7 @@ case: (get_proc p) => [n1 d1 p1|n1 dst1 d1 p1|n1 frm1 f1|d1||n1] /=.
 - by move=> ->; exact (ltnW Hsz).
 Qed.
 
-Lemma size_interp h (procs : seq (aproc data)) (traces : seq (seq data)) :
+Lemma size_interp h (procs : seq (proc data)) (traces : seq (seq data)) :
   size procs = size traces ->
   size (interp h procs traces).1 = size procs /\
   size (interp h procs traces).2 = size procs.
@@ -390,7 +414,7 @@ move=> -> ->.
 by rewrite !size_map size_iota.
 Qed.
 
-Lemma size_traces_nth h (procs : seq (aproc data)) (i : 'I_(size procs)) :
+Lemma size_traces_nth h (procs : seq (proc data)) (i : 'I_(size procs)) :
   (size (nth [::] (run_interp h procs).2 i) <= h)%N.
 Proof.
 by apply/size_traces/mem_nth; rewrite (size_interp _ _).2 // size_nseq.
@@ -431,15 +455,15 @@ Section termination.
 Variable data : Type.
 
 (* Check if a process is in a final state (Finish or Fail) *)
-Definition is_final (p : aproc data) : bool :=
-  match get_proc p with
+Definition is_final (p : proc data) : bool :=
+  match p with
   | Finish => true
-  | @Fail _ _ => true
+  | Fail => true
   | _ => false
   end.
 
 (* Check if all processes in a list are in final states *)
-Definition all_final (ps : seq (aproc data)) : bool :=
+Definition all_final (ps : seq (proc data)) : bool :=
   all is_final ps.
 
 End termination.


### PR DESCRIPTION
This is a quick try to remove the fuel from the interpreter, keeping it only in the input programs.
More or less necessary to work on the metatheory of the interpreter.
Could then prove separately that a program with known fuel requirement produce only traces shorter than this requirement.